### PR TITLE
Add basic sales and inventory application skeleton

### DIFF
--- a/app/src/main/java/com/example/ventasryc/MainActivity.kt
+++ b/app/src/main/java/com/example/ventasryc/MainActivity.kt
@@ -4,13 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.example.ventasryc.data.*
+import com.example.ventasryc.ui.*
 import com.example.ventasryc.ui.theme.VentasRyCTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +18,40 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             VentasRyCTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                SalesApp()
             }
         }
     }
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
+fun SalesApp() {
+    val products = remember { mutableStateListOf<Product>() }
+    val sales = remember { mutableStateListOf<Sale>() }
+    val appointments = remember { mutableStateListOf<Appointment>() }
+    val customers = remember { mutableStateListOf<Customer>() }
+    var selectedTab by remember { mutableStateOf(0) }
+    val tabs = listOf("Ventas", "Inventario", "Agenda", "Clientes", "Reporte")
 
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    VentasRyCTheme {
-        Greeting("Android")
+    Scaffold(
+        topBar = {
+            TabRow(selectedTabIndex = selectedTab) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = selectedTab == index,
+                        onClick = { selectedTab = index },
+                        text = { Text(title) }
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
+        when (selectedTab) {
+            0 -> SalesScreen(products, sales, Modifier.padding(innerPadding))
+            1 -> InventoryScreen(products, Modifier.padding(innerPadding))
+            2 -> AgendaScreen(appointments, Modifier.padding(innerPadding))
+            3 -> RecommendationScreen(customers, Modifier.padding(innerPadding))
+            4 -> ReportScreen(sales, Modifier.padding(innerPadding))
+        }
     }
 }

--- a/app/src/main/java/com/example/ventasryc/data/Models.kt
+++ b/app/src/main/java/com/example/ventasryc/data/Models.kt
@@ -1,0 +1,40 @@
+package com.example.ventasryc.data
+
+// Data model for a product in inventory
+// photoUri stores the path to the product image
+// cost represents investment per item, price is sale price
+
+data class Product(
+    val id: Int,
+    val name: String,
+    val cost: Double,
+    val price: Double,
+    val quantity: Int,
+    val photoUri: String? = null
+)
+
+// Represents a sale of a product
+// timestamp allows real time calculation
+
+data class Sale(
+    val productId: Int,
+    val quantity: Int,
+    val timestamp: Long = System.currentTimeMillis()
+)
+
+// Represents an appointment with a customer
+// alarmTime in millis can be used with AlarmManager
+
+data class Appointment(
+    val id: Int,
+    val customer: String,
+    val alarmTime: Long
+)
+
+// Simple customer model used for recommendations
+
+data class Customer(
+    val id: Int,
+    val name: String,
+    val totalSpent: Double
+)

--- a/app/src/main/java/com/example/ventasryc/ui/Screens.kt
+++ b/app/src/main/java/com/example/ventasryc/ui/Screens.kt
@@ -1,0 +1,206 @@
+package com.example.ventasryc.ui
+
+import android.content.Context
+import android.graphics.pdf.PdfDocument
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.example.ventasryc.data.*
+import java.io.File
+import java.io.FileOutputStream
+
+// Screen to manage sales in real time and calculate investment/profit
+@Composable
+fun SalesScreen(products: List<Product>, sales: MutableList<Sale>, modifier: Modifier = Modifier) {
+    var productId by remember { mutableStateOf(TextFieldValue()) }
+    var quantity by remember { mutableStateOf(TextFieldValue()) }
+
+    val totalSales = remember(sales, products) {
+        sales.sumOf { sale ->
+            val product = products.find { it.id == sale.productId }
+            (product?.price ?: 0.0) * sale.quantity
+        }
+    }
+    val totalInvestment = remember(sales, products) {
+        sales.sumOf { sale ->
+            val product = products.find { it.id == sale.productId }
+            (product?.cost ?: 0.0) * sale.quantity
+        }
+    }
+    val profit = totalSales - totalInvestment
+
+    Column(modifier.padding(16.dp)) {
+        Text("Total ventas: $%.2f".format(totalSales))
+        Text("Inversión: $%.2f".format(totalInvestment))
+        Text("Ganancia: $%.2f".format(profit))
+        Spacer(Modifier.height(16.dp))
+        OutlinedTextField(
+            value = productId,
+            onValueChange = { productId = it },
+            label = { Text("ID Producto") }
+        )
+        OutlinedTextField(
+            value = quantity,
+            onValueChange = { quantity = it },
+            label = { Text("Cantidad") },
+            modifier = Modifier.padding(top = 8.dp)
+        )
+        Button(
+            onClick = {
+                val id = productId.text.toIntOrNull()
+                val qty = quantity.text.toIntOrNull()
+                if (id != null && qty != null) {
+                    sales.add(Sale(id, qty))
+                    productId = TextFieldValue("")
+                    quantity = TextFieldValue("")
+                }
+            },
+            modifier = Modifier.padding(top = 8.dp)
+        ) {
+            Text("Agregar venta")
+        }
+    }
+}
+
+// Inventory of products. Photo is represented by a URL string for simplicity.
+@Composable
+fun InventoryScreen(products: MutableList<Product>, modifier: Modifier = Modifier) {
+    var name by remember { mutableStateOf(TextFieldValue()) }
+    var cost by remember { mutableStateOf(TextFieldValue()) }
+    var price by remember { mutableStateOf(TextFieldValue()) }
+    var qty by remember { mutableStateOf(TextFieldValue()) }
+    var photo by remember { mutableStateOf(TextFieldValue()) }
+
+    Column(modifier.padding(16.dp)) {
+        LazyColumn(Modifier.height(200.dp)) {
+            items(products) { product ->
+                Text("${product.name} - ${product.quantity}")
+            }
+        }
+        OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Nombre") })
+        OutlinedTextField(value = cost, onValueChange = { cost = it }, label = { Text("Costo") })
+        OutlinedTextField(value = price, onValueChange = { price = it }, label = { Text("Precio") })
+        OutlinedTextField(value = qty, onValueChange = { qty = it }, label = { Text("Cantidad") })
+        OutlinedTextField(value = photo, onValueChange = { photo = it }, label = { Text("Foto (URI)") })
+        Button(onClick = {
+            val pCost = cost.text.toDoubleOrNull()
+            val pPrice = price.text.toDoubleOrNull()
+            val pQty = qty.text.toIntOrNull()
+            if (name.text.isNotBlank() && pCost != null && pPrice != null && pQty != null) {
+                products.add(
+                    Product(
+                        id = products.size + 1,
+                        name = name.text,
+                        cost = pCost,
+                        price = pPrice,
+                        quantity = pQty,
+                        photoUri = if (photo.text.isBlank()) null else photo.text
+                    )
+                )
+                name = TextFieldValue("")
+                cost = TextFieldValue("")
+                price = TextFieldValue("")
+                qty = TextFieldValue("")
+                photo = TextFieldValue("")
+            }
+        }, modifier = Modifier.padding(top = 8.dp)) {
+            Text("Agregar producto")
+        }
+    }
+}
+
+// Agenda of appointments with alarmTime placeholder.
+@Composable
+fun AgendaScreen(appointments: MutableList<Appointment>, modifier: Modifier = Modifier) {
+    var customer by remember { mutableStateOf(TextFieldValue()) }
+    var alarm by remember { mutableStateOf(TextFieldValue()) }
+
+    Column(modifier.padding(16.dp)) {
+        LazyColumn(Modifier.height(200.dp)) {
+            items(appointments) { appt ->
+                Text("${appt.customer} - ${appt.alarmTime}")
+            }
+        }
+        OutlinedTextField(value = customer, onValueChange = { customer = it }, label = { Text("Cliente") })
+        OutlinedTextField(value = alarm, onValueChange = { alarm = it }, label = { Text("Alarm (ms)") })
+        Button(onClick = {
+            val time = alarm.text.toLongOrNull()
+            if (customer.text.isNotBlank() && time != null) {
+                appointments.add(Appointment(appointments.size + 1, customer.text, time))
+                customer = TextFieldValue("")
+                alarm = TextFieldValue("")
+            }
+        }, modifier = Modifier.padding(top = 8.dp)) {
+            Text("Agregar apartado")
+        }
+    }
+}
+
+// Simple recommendation: lists customers ordered by spending
+@Composable
+fun RecommendationScreen(customers: MutableList<Customer>, modifier: Modifier = Modifier) {
+    var name by remember { mutableStateOf(TextFieldValue()) }
+    var spent by remember { mutableStateOf(TextFieldValue()) }
+
+    val ordered = customers.sortedByDescending { it.totalSpent }
+
+    Column(modifier.padding(16.dp)) {
+        LazyColumn(Modifier.height(200.dp)) {
+            items(ordered) { customer ->
+                Text("${customer.name} - $${customer.totalSpent}")
+            }
+        }
+        OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Cliente") })
+        OutlinedTextField(value = spent, onValueChange = { spent = it }, label = { Text("Gastado") })
+        Button(onClick = {
+            val amount = spent.text.toDoubleOrNull()
+            if (name.text.isNotBlank() && amount != null) {
+                customers.add(Customer(customers.size + 1, name.text, amount))
+                name = TextFieldValue("")
+                spent = TextFieldValue("")
+            }
+        }, modifier = Modifier.padding(top = 8.dp)) {
+            Text("Agregar cliente")
+        }
+    }
+}
+
+// Generates a very simple PDF summary of sales
+fun generateMonthlyReport(context: Context, sales: List<Sale>): File {
+    val pdf = PdfDocument()
+    val pageInfo = PdfDocument.PageInfo.Builder(300, 400, 1).create()
+    val page = pdf.startPage(pageInfo)
+    val canvas = page.canvas
+    val paint = android.graphics.Paint().apply { color = android.graphics.Color.BLACK; textSize = 12f }
+    var y = 25f
+    canvas.drawText("Reporte de ventas", 10f, y, paint)
+    sales.forEach {
+        y += 20f
+        canvas.drawText("Producto ${it.productId} x${it.quantity}", 10f, y, paint)
+    }
+    pdf.finishPage(page)
+    val file = File(context.cacheDir, "reporte_mensual.pdf")
+    pdf.writeTo(FileOutputStream(file))
+    pdf.close()
+    return file
+}
+
+@Composable
+fun ReportScreen(sales: List<Sale>, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    var generatedFile by remember { mutableStateOf<File?>(null) }
+    Column(modifier.padding(16.dp)) {
+        Button(onClick = { generatedFile = generateMonthlyReport(context, sales) }) {
+            Text("Generar PDF mensual")
+        }
+        generatedFile?.let {
+            Text("Generado: ${it.absolutePath}")
+        }
+    }
+}

--- a/app/src/main/java/com/example/ventasryc/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/ventasryc/ui/theme/Color.kt
@@ -2,10 +2,11 @@ package com.example.ventasryc.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+// Purple, blue and black palette for minimalist interface
+val PurplePrimary = Color(0xFF800080)
+val BlueSecondary = Color(0xFF1E90FF)
+val BlackTertiary = Color(0xFF000000)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val PurpleDark = Color(0xFF4B0082)
+val BlueDark = Color(0xFF0D47A1)
+val BlackLight = Color(0xFF222222)

--- a/app/src/main/java/com/example/ventasryc/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/ventasryc/ui/theme/Theme.kt
@@ -12,31 +12,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+    primary = PurpleDark,
+    secondary = BlueDark,
+    tertiary = BlackLight
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    primary = PurplePrimary,
+    secondary = BlueSecondary,
+    tertiary = BlackTertiary
 )
 
 @Composable
 fun VentasRyCTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
@@ -45,7 +34,6 @@ fun VentasRyCTheme(
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }


### PR DESCRIPTION
## Summary
- implement data models for products, sales, appointments and customers
- add composable screens for sales, inventory, agenda, customer recommendations and PDF reports
- apply minimalist purple/blue/black theme

## Testing
- `sh gradlew test -q --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dc610ed483268cc20b642441730c